### PR TITLE
Feat: Add biometric user authentication support and test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.vscode
+/.cargo
 /target
+keyring-tester/app/src/main/jniLibs/
+keyring-tester/local.properties

--- a/keyring-tester/build.gradle.kts
+++ b/keyring-tester/build.gradle.kts
@@ -3,3 +3,61 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
 }
+
+val adb: String = providers.environmentVariable("ANDROID_HOME")
+    .orElse(providers.systemProperty("android.home"))
+    .map { "$it/platform-tools/adb" }
+    .getOrElse("adb")
+
+val appId = "com.brotsky.android.testing.keyring"
+val pin = "1234"
+
+tasks.register<Exec>("ensurePin") {
+    description = "Ensures the emulator has a PIN lock screen configured"
+    commandLine(adb, "shell", "locksettings", "set-pin", "--old", pin, pin)
+    isIgnoreExitValue = true
+}
+
+tasks.register("unlockDevice") {
+    description = "Locks then unlocks the device with PIN to refresh auth timeout"
+    dependsOn("ensurePin")
+    doLast {
+        exec { commandLine(adb, "shell", "input", "keyevent", "KEYCODE_SLEEP") }
+        Thread.sleep(1000)
+        exec { commandLine(adb, "shell", "input", "keyevent", "KEYCODE_WAKEUP") }
+        Thread.sleep(1000)
+        exec { commandLine(adb, "shell", "input", "swipe", "540", "1800", "540", "400") }
+        Thread.sleep(1000)
+        exec { commandLine(adb, "shell", "input", "text", pin) }
+        Thread.sleep(500)
+        exec { commandLine(adb, "shell", "input", "keyevent", "KEYCODE_ENTER") }
+        Thread.sleep(2000)
+    }
+}
+
+tasks.register("runTests") {
+    description = "Builds, installs, and runs the keyring test app on the connected device"
+    dependsOn(":app:installDebug", "unlockDevice")
+    doLast {
+        exec { commandLine(adb, "logcat", "-c") }
+        exec { commandLine(adb, "shell", "am", "force-stop", appId) }
+        Thread.sleep(500)
+        exec {
+            commandLine(adb, "shell", "am", "start", "-n", "$appId/.MainActivity")
+        }
+        Thread.sleep(8000)
+        val output = java.io.ByteArrayOutputStream()
+        exec {
+            commandLine(adb, "logcat", "-d", "-s", "unit-test")
+            standardOutput = output
+        }
+        val results = output.toString()
+        println(results)
+        if (results.contains(" E unit-test:")) {
+            throw GradleException("One or more tests failed. See logcat output above.")
+        }
+        if (!results.contains("All tests complete")) {
+            throw GradleException("Tests did not complete. App may have crashed.")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
  - Adds user-auth-required and user-auth-timeout modifier support for Android KeyStore biometric authentication
  - When user-auth-required is set, KeyStore keys are generated with setUserAuthenticationRequired(true) and configurable timeout
  - Adds biometric test cases to the existing keyring-tester and a Gradle runTests task that automates emulator setup and test execution

  ### Changes
  - src/credential.rs — Parses user-auth-required and user-auth-timeout modifiers, applies setUserAuthenticationRequired and setUserAuthenticationValidityDurationSeconds to KeyGenParameterSpec
  - src/keystore.rs — New module extracting KeyStore operations with biometric-aware key generation
  - src/tests.rs — Added bio_golden_path, bio_delete_credential, bio_concurrent_access tests using Entry::new_with_modifiers
  - keyring-tester/build.gradle.kts — Added ensurePin, unlockDevice, and runTests Gradle tasks for automated emulator testing
  - .gitignore — Added .cargo, jniLibs/, local.properties

  ### Test plan
  - ./gradlew runTests on a connected emulator — sets up PIN, unlocks device, runs all 10 tests (7 original + 3 biometric)
  - Biometric tests use 30-second auth timeout so they pass on emulators with PIN set